### PR TITLE
Code sniffer is installed on cmd image.

### DIFF
--- a/docker/dockerfile/cmd
+++ b/docker/dockerfile/cmd
@@ -23,6 +23,7 @@ RUN apt-get update \
     && pecl install xdebug && docker-php-ext-enable xdebug && rm -rf /tmp/pear/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && mkdir -p ~/.composer/cache/ && chmod -R 777 ~/.composer/cache/ \
 	&& composer global require "laravel/installer" \
+    && composer global require "squizlabs/php_codesniffer=*" \
     && apt-get clean && rm -rf /var/lib/apt/list/*
 ENV PATH ~/.composer/vendor/bin:$PATH
 ENV PATH /usr/share/nginx/WEBAPP/vendor/bin:$PATH


### PR DESCRIPTION
Now you can user following commands
- PHP Code Sniffer
  - `phpcs --standard=PSR2 <file-path.php|path-to-folder>`
- PHP Code Beautifier and Fixer
  - `phpcbf --standard=PSR2 <file-path.php|path-to-folder>`
