### PR TITLE
Elixir support for windows vm work around

### DIFF
--- a/docker/dockerfile/cmd
+++ b/docker/dockerfile/cmd
@@ -31,8 +31,9 @@ ENV PATH /usr/share/nginx/WEBAPP/vendor/bin:$PATH
 STOPSIGNAL SIGKILL
 CMD ~/.composer/vendor/bin/phpcs --config-show && /bin/bash -c "while true; do echo 1; sleep 1; done"
 
-RUN curl -sL https://deb.nodesource.com/setup_4.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_5.x | bash - \
     && apt-get install -y nodejs \
+    && apt-get install -y libnotify-bin \
     && apt-get clean && rm -rf /var/lib/apt/list/*
 RUN npm install --global gulp@^3.8.8
 #end everything specific 'dlemp_cmd' file

--- a/docker/dockerfile/cmd
+++ b/docker/dockerfile/cmd
@@ -37,3 +37,10 @@ RUN curl -sL https://deb.nodesource.com/setup_5.x | bash - \
     && apt-get clean && rm -rf /var/lib/apt/list/*
 RUN npm install --global gulp@^3.8.8
 #end everything specific 'dlemp_cmd' file
+
+#start partial support for Laravel Elixir on windows VM
+RUN mkdir -p /DLEMP/nodejs \
+    && ln -s /usr/share/nginx/WEBAPP/package.json /DLEMP/nodejs/package.json \
+    && ln -s /usr/share/nginx/WEBAPP/resources /DLEMP/nodejs/resources \
+    && ln -s /usr/share/nginx/WEBAPP/public /DLEMP/nodejs/public
+#end partial support for Laravel Elixir on windows VM


### PR DESCRIPTION
This PR targets issue #11.

Only a single file, 'cmd', is changed to add the support. All commands are added in a single block at the end of the file. So if this issue get resolved by Microsoft or Docker, then we can easily remove the work around that we have added to this repository.
