### PR TITLE
Add xdebug support

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -19,8 +19,6 @@ services:
         build:
             dockerfile: ${DLEMP_BASE_DIR}docker/dockerfile/phpfpmdev
         image: dlemp/phpfpm
-        extra_hosts:
-            - "xdebugremotehost:10.0.75.1"
         volumes:
             - .:/usr/share/nginx/WEBAPP
             - ./${DLEMP_BASE_DIR}docker/docker-config/php.ini-development-delta:/usr/local/etc/php/conf.d/development.ini

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -16,6 +16,9 @@ services:
             - "25"
 #end These services can be disabled without affecting any other services
     phpfpm:
+        build:
+            dockerfile: ${DLEMP_BASE_DIR}docker/dockerfile/phpfpmdev
+        image: dlemp/phpfpm
         volumes:
             - .:/usr/share/nginx/WEBAPP
             - ./${DLEMP_BASE_DIR}docker/docker-config/php.ini-development-delta:/usr/local/etc/php/conf.d/development.ini

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -19,6 +19,8 @@ services:
         build:
             dockerfile: ${DLEMP_BASE_DIR}docker/dockerfile/phpfpmdev
         image: dlemp/phpfpm
+        extra_hosts:
+            - "xdebugremotehost:10.0.75.1"
         volumes:
             - .:/usr/share/nginx/WEBAPP
             - ./${DLEMP_BASE_DIR}docker/docker-config/php.ini-development-delta:/usr/local/etc/php/conf.d/development.ini

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,6 @@ services:
             dockerfile: ${DLEMP_BASE_DIR}docker/dockerfile/phpfpm
             args:
                 DLEMP_BASE_DIR: ${DLEMP_BASE_DIR}
-        image: dlemp/phpfpm
         expose:
             - "9000"
     nginxhttps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
             dockerfile: ${DLEMP_BASE_DIR}docker/dockerfile/nodesocket
             args:
                 DLEMP_BASE_DIR: ${DLEMP_BASE_DIR}
+        depends_on:
+            - redis
         volumes_from:
             - nginxhttp:ro
         expose:

--- a/docker/dockerfile/cmd
+++ b/docker/dockerfile/cmd
@@ -3,7 +3,6 @@ FROM dlemp/phpfpm
 #start everything specific 'dlemp_cmd' file
 RUN apt-get update \
     && apt-get -y install curl git \
-    && pecl install xdebug && docker-php-ext-enable xdebug && rm -rf /tmp/pear/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && mkdir -p ~/.composer/cache/ && chmod -R 777 ~/.composer/cache/ \
 	&& composer global require "laravel/installer" \
     && composer global require "squizlabs/php_codesniffer=*" && ~/.composer/vendor/bin/phpcs --config-set defalt_standard PSR2 \

--- a/docker/dockerfile/phpfpm
+++ b/docker/dockerfile/phpfpm
@@ -18,8 +18,10 @@ COPY ${DLEMP_BASE_DIR}docker/docker-config/php.ini-common-delta /usr/local/etc/p
 
 WORKDIR /usr/share/nginx/WEBAPP
 
-COPY . /usr/share/nginx/WEBAPP
-RUN chown -R www-data:www-data /usr/share/nginx/WEBAPP && chmod -R 755 /usr/share/nginx/WEBAPP
-
 CMD ["php-fpm"]
 #end common phpfpm instructions
+
+#start everything specific to phpfpm
+COPY . /usr/share/nginx/WEBAPP
+RUN chown -R www-data:www-data /usr/share/nginx/WEBAPP && chmod -R 755 /usr/share/nginx/WEBAPP
+#end everything specific to phpfpm

--- a/docker/dockerfile/phpfpmdev
+++ b/docker/dockerfile/phpfpmdev
@@ -24,10 +24,11 @@ CMD ["php-fpm"]
 #start everything specific to phpfpmdev
 RUN pecl install xdebug && docker-php-ext-enable xdebug && rm -rf /tmp/pear/*
 RUN printf "\n\
-xdebug.remote_enable=1\n\
-xdebug.remote_connect_back=1\n\
-xdebug.remote_port=9000\n\
-xdebug.remote_handler=dbgp\n\
-xdebug.remote_mode=req\n\
-xdebug.cli_color=1\n" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+xdebug.remote_enable = On\n\
+xdebug.remote_connect_back = On\n\
+xdebug.remote_port = 9000\n\
+xdebug.remote_handler = dbgp\n\
+xdebug.remote_mode = req\n\
+xdebug.cli_color = On\n\
+xdebug.overload_var_dump = 2\n" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 #start everything specific to phpfpmdev

--- a/docker/dockerfile/phpfpmdev
+++ b/docker/dockerfile/phpfpmdev
@@ -25,7 +25,6 @@ CMD ["php-fpm"]
 RUN pecl install xdebug && docker-php-ext-enable xdebug && rm -rf /tmp/pear/*
 RUN printf "\n\
 xdebug.remote_enable=1\n\
-xdebug.remote_host=xdebugremotehost\n\
 xdebug.remote_connect_back=1\n\
 xdebug.remote_port=9000\n\
 xdebug.remote_handler=dbgp\n\

--- a/docker/dockerfile/phpfpmdev
+++ b/docker/dockerfile/phpfpmdev
@@ -18,13 +18,10 @@ COPY ${DLEMP_BASE_DIR}docker/docker-config/php.ini-common-delta /usr/local/etc/p
 
 WORKDIR /usr/share/nginx/WEBAPP
 
-COPY . /usr/share/nginx/WEBAPP
-RUN chown -R www-data:www-data /usr/share/nginx/WEBAPP && chmod -R 755 /usr/share/nginx/WEBAPP
-
 CMD ["php-fpm"]
 #end common phpfpm instructions
 
-#start everything specific to phpfpm-dev
+#start everything specific to phpfpmdev
 RUN pecl install xdebug && docker-php-ext-enable xdebug && rm -rf /tmp/pear/*
 RUN printf "\n\
 xdebug.remote_enable=1\n\
@@ -34,4 +31,4 @@ xdebug.remote_port=9000\n\
 xdebug.remote_handler=dbgp\n\
 xdebug.remote_mode=req\n\
 xdebug.cli_color=1\n" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
-#start everything specific to phpfpm-dev
+#start everything specific to phpfpmdev

--- a/docker/dockerfile/phpfpmdev
+++ b/docker/dockerfile/phpfpmdev
@@ -23,3 +23,7 @@ RUN chown -R www-data:www-data /usr/share/nginx/WEBAPP && chmod -R 755 /usr/shar
 
 CMD ["php-fpm"]
 #end common phpfpm instructions
+
+#start everything specific to phpfpm-dev
+RUN pecl install xdebug && docker-php-ext-enable xdebug && rm -rf /tmp/pear/*
+#start everything specific to phpfpm-dev

--- a/docker/dockerfile/phpfpmdev
+++ b/docker/dockerfile/phpfpmdev
@@ -26,4 +26,12 @@ CMD ["php-fpm"]
 
 #start everything specific to phpfpm-dev
 RUN pecl install xdebug && docker-php-ext-enable xdebug && rm -rf /tmp/pear/*
+RUN printf "\n\
+xdebug.remote_enable=1\n\
+xdebug.remote_host=xdebugremotehost\n\
+xdebug.remote_connect_back=1\n\
+xdebug.remote_port=9000\n\
+xdebug.remote_handler=dbgp\n\
+xdebug.remote_mode=req\n\
+xdebug.cli_color=1\n" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 #start everything specific to phpfpm-dev

--- a/public/test_server_6_xdebug.php
+++ b/public/test_server_6_xdebug.php
@@ -1,11 +1,24 @@
 <?php
 
+//start print xdebug configurations
+$xdebug_enabled= 'No';
+if(isset($_COOKIE['XDEBUG_SESSION'])){
+    $xdebug_enabled= "Yes({$_COOKIE['XDEBUG_SESSION']})";
+}
+print("'XDEBUG_SESSION' cookie set to initiate a debugging session: $xdebug_enabled<br/>");
+print("Xdebug will connect to host at: {$_SERVER['REMOTE_ADDR']}<br/>");
+print("Xdebug will connect the host at port: ".ini_get('xdebug.remote_port')."<br/>");
+print("<br/>");
+//end print xdebug configurations
+
+//start example code where you can add break point and check if debugger if working or not
 function add_numbers($a, $b){
     $sum= 0;
     $sum= $a + $b;
     return $sum;
 }
 
-$total= 0;
+$total= 0;//insert bread point here for checking if xdebug is working or not
 $total= add_numbers(2, 3);
 print("Total is: $total");
+//end example code where you can add break point and check if debugger if working or not

--- a/public/test_server_6_xdebug.php
+++ b/public/test_server_6_xdebug.php
@@ -1,0 +1,11 @@
+<?php
+
+function add_numbers($a, $b){
+    $sum= 0;
+    $sum= $a + $b;
+    return $sum;
+}
+
+$total= 0;
+$total= add_numbers(2, 3);
+print("Total is: $total");

--- a/tests/A00PHPDlempTest.php
+++ b/tests/A00PHPDlempTest.php
@@ -2,6 +2,16 @@
 
 class A00PHPDlempTest extends TestCase
 {
+    public function testCustomProductionSettings(){
+        $this->assertSame('GPCS', ini_get('variables_order'));
+        $this->assertSame('GP', ini_get('request_order'));
+    }
+
+    public function testCustomDevelopmentSettings(){
+        $this->assertSame(strval(E_ALL), ini_get('error_reporting'));
+        $this->assertSame('1', ini_get('display_errors'));
+        $this->assertSame('1', ini_get('display_startup_errors'));
+    }
 
     public function testExtensionCurl()
     {
@@ -19,5 +29,13 @@ class A00PHPDlempTest extends TestCase
             $this->isExtensionLoaded('xdebug'),
             "Xdebug is not installed. You will not be able to generate PHPUnit code coverage report."
         );
+
+        $this->assertSame('1', ini_get('xdebug.remote_enable'));
+        $this->assertSame('1', ini_get('xdebug.remote_connect_back'));
+        $this->assertSame('9000', ini_get('xdebug.remote_port'));
+        $this->assertSame('dbgp', ini_get('xdebug.remote_handler'));
+        $this->assertSame('req', ini_get('xdebug.remote_mode'));
+        $this->assertSame('1', ini_get('xdebug.cli_color'));
+        $this->assertSame('2', ini_get('xdebug.overload_var_dump'));
     }
 }


### PR DESCRIPTION
Need to configure following things for xdebug to work
1. McAfee : 'Firewall->Ports and System Services->Add' port 9000 to allow xdebug to connect and 'Firewall->Smart Advice and Advanced Settings->Allow ICMP ping request' to allow ping from VM to host.
2. Install extensions 'The easiest Xdebug' in Firefox or 'Xdebug Helper' in Chrome. Using the installed extensions initiate a debugging session.
3. Open '~/.atom/config.cson' and set path map to '/usr/share/nginx/WEBAPP;C:\Users\&lt;user-name>\php-projects\DLEMP' (Example: https://atom.io/packages/php-debug)
4. Open 'PHP Debug' panel in Atom. 'PHP Debug' will not start listening for incoming connections until you open the panel.
*Note: If xdebug doesn't work, then you should try to ping $_SERVER['REMOTE_ADDR'] ip from phpfpm container to make sure that your firewall isn't blocking xdebug from connecting to your IDE.
