### PR TITLE
Installed OPCache on production phpfpm image.

### DIFF
--- a/Command to build
+++ b/Command to build
@@ -25,7 +25,8 @@ docker push rasodu/nodesocket:4.4.<version_number>
     //end push nodesocket image
 
     //start push phpfpm
-docker history dlemp/phpfpm
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml build phpfpm
+docker history dlemp_phpfpm
 docker tag <image-id-of-layer> rasodu/phpfpm:5.6.<version_number>//Tag at layer before installing xdebug
 docker push rasodu/phpfpm:5.6.<version_number>
     //end push phpfpm

--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ and Digital Ocean). Use service like
 Mailgun for SMTP during production.
 Though we will provide Mailtrap for you
 to use in development.
+
+**How do I run/stop this project**
+- Run project
+    - ```docker-compose up -d``` - Run project in development mode
+        - ```phpunit --exclude-group prod``` - Run unittests in `cmd` container
+        - ```vendor/bin/phpunit --exclude-group cmd,prod``` - Run unittests in `phpfpmdev` container
+    - ```docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d``` - Run project in production mode
+        - ```vendor/bin/phpunit --exclude-group dev,cmd``` - Run unittests in `phpfpm` container
+- Stop project
+    - ```docker-compose down [--rmi local] -v```

--- a/docker/docker-config/php.ini-common-delta
+++ b/docker/docker-config/php.ini-common-delta
@@ -20,3 +20,12 @@ request_order = "GP"
 
 ; This feature is disabled by default. If this is enabled, then the request will be allowed to complete even if user
 ;ignore_user_abort = On
+
+
+; OPCache settings but this is useless if OPCache is not enabled.
+opcache.enable_cli = On
+opcache.memory_consumption = 128
+opcache.max_accelerated_files = 8000
+opcache.revalidate_freq = 60
+opcache.max_wasted_percentage = 5
+opcache.fast_shutdown = On

--- a/docker/dockerfile/56phpfpm
+++ b/docker/dockerfile/56phpfpm
@@ -23,6 +23,10 @@ CMD ["php-fpm"]
 #end common phpfpm instructions
 
 #start everything specific to phpfpm
+    #start install OPCache
+RUN docker-php-ext-install opcache
+    #end install OPCache
+
 COPY . /usr/share/nginx/WEBAPP
 RUN chown -R www-data:www-data /usr/share/nginx/WEBAPP \
     && chmod -R 555 /usr/share/nginx/WEBAPP \

--- a/docker/dockerfile/70phpfpm
+++ b/docker/dockerfile/70phpfpm
@@ -11,10 +11,10 @@ RUN apt-get update && apt-get -y install wget \
     && apt-get -y install libmcrypt-dev && docker-php-ext-install mcrypt \
     && apt-get -y install zlib1g zlib1g-dev && docker-php-ext-install zip \
     && apt-get -y install libmemcached-dev zlib1g-dev \
-    && wget https://github.com/php-memcached-dev/php-memcached/archive/php7.tar.gz --output-document=/usr/src/php/ext/memcached.tgz.gz \
+    && curl -L https://github.com/php-memcached-dev/php-memcached/archive/php7.tar.gz --create-dirs --output /usr/src/php/ext/memcached.tgz.gz \
     && mkdir /usr/src/php/ext/memcached && tar xf /usr/src/php/ext/memcached.tgz.gz -C /usr/src/php/ext/memcached --strip-components 1 && rm /usr/src/php/ext/memcached.tgz.gz \
-    && docker-php-ext-install memcached \
-    && rm -rf /tmp/pear/* && apt-get clean && rm -rf /var/lib/apt/lists/*
+    && cd /usr/src/php/ext/memcached && phpize && ./configure && make && make install && docker-php-ext-enable memcached && rm -r /usr/src/php && cd / \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY ${DLEMP_BASE_DIR}docker/docker-config/php-fpm.conf /usr/local/etc/
 COPY ${DLEMP_BASE_DIR}docker/docker-config/php${DLEMP_PHP_VERSION}.ini-production /usr/local/etc/php/php.ini
@@ -26,6 +26,10 @@ CMD ["php-fpm"]
 #end common phpfpm instructions
 
 #start everything specific to phpfpm
+    #start install OPCache
+RUN docker-php-ext-install opcache
+    #end install OPCache
+
 COPY . /usr/share/nginx/WEBAPP
 RUN chown -R www-data:www-data /usr/share/nginx/WEBAPP \
     && chmod -R 555 /usr/share/nginx/WEBAPP \

--- a/docker/dockerfile/70phpfpmdev
+++ b/docker/dockerfile/70phpfpmdev
@@ -11,10 +11,10 @@ RUN apt-get update && apt-get -y install wget \
     && apt-get -y install libmcrypt-dev && docker-php-ext-install mcrypt \
     && apt-get -y install zlib1g zlib1g-dev && docker-php-ext-install zip \
     && apt-get -y install libmemcached-dev zlib1g-dev \
-    && wget https://github.com/php-memcached-dev/php-memcached/archive/php7.tar.gz --output-document=/usr/src/php/ext/memcached.tgz.gz \
+    && curl -L https://github.com/php-memcached-dev/php-memcached/archive/php7.tar.gz --create-dirs --output /usr/src/php/ext/memcached.tgz.gz \
     && mkdir /usr/src/php/ext/memcached && tar xf /usr/src/php/ext/memcached.tgz.gz -C /usr/src/php/ext/memcached --strip-components 1 && rm /usr/src/php/ext/memcached.tgz.gz \
-    && docker-php-ext-install memcached \
-    && rm -rf /tmp/pear/* && apt-get clean && rm -rf /var/lib/apt/lists/*
+    && cd /usr/src/php/ext/memcached && phpize && ./configure && make && make install && docker-php-ext-enable memcached && rm -r /usr/src/php && cd / \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY ${DLEMP_BASE_DIR}docker/docker-config/php-fpm.conf /usr/local/etc/
 COPY ${DLEMP_BASE_DIR}docker/docker-config/php${DLEMP_PHP_VERSION}.ini-production /usr/local/etc/php/php.ini

--- a/docker/dockerfile/s3mock
+++ b/docker/dockerfile/s3mock
@@ -2,7 +2,7 @@ FROM lphoward/fake-s3
 ARG DLEMP_BASE_DIR
 
 #start install s3cmd
-RUN apt-get update && apt-get -y install python-pip \
+RUN apt-get update && apt-get -y --force-yes install python-pip \
     && pip install s3cmd==1.6.1 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 #end install s3cmd

--- a/tests/A00PHPDlempTest.php
+++ b/tests/A00PHPDlempTest.php
@@ -2,15 +2,30 @@
 
 class A00PHPDlempTest extends TestCase
 {
-    public function testCustomProductionSettings(){
+    public function testCustomCommonSettings()
+    {
         $this->assertSame('GPCS', ini_get('variables_order'));
         $this->assertSame('GP', ini_get('request_order'));
     }
 
-    public function testCustomDevelopmentSettings(){
+    /**
+    *@group dev
+    */
+    public function testCustomDevelopmentSettings()
+    {
         $this->assertSame(strval(E_ALL), ini_get('error_reporting'));
         $this->assertSame('1', ini_get('display_errors'));
         $this->assertSame('1', ini_get('display_startup_errors'));
+    }
+
+    /**
+    *@group prod
+    */
+    public function testProductionSettings()
+    {
+        $this->assertSame(strval(E_ALL - E_DEPRECATED - E_STRICT), ini_get('error_reporting'));
+        $this->assertSame('', ini_get('display_errors'));
+        $this->assertSame('', ini_get('display_startup_errors'));
     }
 
     public function testExtensionCurl()
@@ -20,22 +35,5 @@ class A00PHPDlempTest extends TestCase
             $this->isExtensionLoaded('curl'),
             "Curl not installed. A lot of unittest will be skipped."
         );
-    }
-
-    public function testExtensionXdebug()
-    {
-        $this->assertSame(
-            true,
-            $this->isExtensionLoaded('xdebug'),
-            "Xdebug is not installed. You will not be able to generate PHPUnit code coverage report."
-        );
-
-        $this->assertSame('1', ini_get('xdebug.remote_enable'));
-        $this->assertSame('1', ini_get('xdebug.remote_connect_back'));
-        $this->assertSame('9000', ini_get('xdebug.remote_port'));
-        $this->assertSame('dbgp', ini_get('xdebug.remote_handler'));
-        $this->assertSame('req', ini_get('xdebug.remote_mode'));
-        $this->assertSame('1', ini_get('xdebug.cli_color'));
-        $this->assertSame('2', ini_get('xdebug.overload_var_dump'));
     }
 }

--- a/tests/A01PHPLaravelTest.php
+++ b/tests/A01PHPLaravelTest.php
@@ -32,12 +32,56 @@ class A01PHPLaravelTest extends TestCase
         );
     }
 
-    public function testStaticStoragefiles()
+    /**
+    *@group dev
+    */
+    public function testStaticStorageFilesServedDuringDevelopment()
     {
         $result= $this->getFullResponseFromURL('https://nginxhttps/storage/static_file.txt');
 
         $this->assertContains(
             'Text in static file.',
+            $result
+        );
+    }
+
+    /**
+    *@group prod
+    */
+    public function testStaticStorageFilesShouldntBeCopiedToProductionVolume()
+    {
+        $result= $this->getFullResponseFromURL('https://nginxhttps/storage/static_file.txt');
+
+        $this->assertContains('HTTP/1.1 404 Not Found', $result);
+    }
+
+    public function testStaticStorageNewFileIsServed()
+    {
+        $file_name= 'static_file9876.txt';
+        $file_folder= '/usr/share/nginx/WEBAPP/storage/app/public/';
+        $file_path= $file_folder.$file_name;
+        $file_content= 'Text in static file.';
+
+        //create files for test
+        $delete_folder= false;
+        if (!file_exists($file_folder)) {
+            $delete_folder= true;
+            mkdir($file_folder);
+        }
+        file_put_contents($file_path, $file_content);
+        //end files for test
+
+        $result= $this->getFullResponseFromURL('https://nginxhttps/storage/'.$file_name);
+
+        //start remove files created for test
+        unlink($file_path);
+        if ($delete_folder) {
+            rmdir($file_folder);
+        }
+        //end remove files created for test
+
+        $this->assertContains(
+            $file_content,
             $result
         );
     }

--- a/tests/A61S3Test.php
+++ b/tests/A61S3Test.php
@@ -15,6 +15,9 @@ use Illuminate\Filesystem\FilesystemAdapter;
 
 use Illuminate\Contracts\Filesystem\Filesystem as FilesystemContract;
 
+/**
+*@group dev
+*/
 class A61S3Test extends TestCase
 {
     private $end_point= 'http://webapp.dev:4569';

--- a/tests/A71PhpcsAndPhpcbfTest.php
+++ b/tests/A71PhpcsAndPhpcbfTest.php
@@ -4,6 +4,9 @@ use Symfony\Component\Process\Process;
 
 class A71PhpcsAndPhpcbfTest extends TestCase
 {
+    /**
+    *@group cmd
+    */
     public function testDefaultStandardForPhpcs()
     {
         $process = new Process('phpcs --config-show standard');
@@ -13,6 +16,9 @@ class A71PhpcsAndPhpcbfTest extends TestCase
         $this->assertEquals("default_standard: PSR2\n", $output);
     }
 
+    /**
+    *@group cmd
+    */
     public function testDefaultStandardForPhpcbf()
     {
         $process = new Process('phpcbf --config-show standard');

--- a/tests/A72PhpDocumentorTest.php
+++ b/tests/A72PhpDocumentorTest.php
@@ -5,6 +5,9 @@ use Symfony\Component\Process\Process;
 class A72PhpDocumentorTest extends TestCase
 {
 
+    /**
+    *@group cmd
+    */
     public function testPhpdocIsInstalled()
     {
         $process = new Process('phpdoc --version');

--- a/tests/A73LaravelInstallerTest.php
+++ b/tests/A73LaravelInstallerTest.php
@@ -5,6 +5,9 @@ use Symfony\Component\Process\Process;
 class A73LaravelInstallerTest extends TestCase
 {
 
+    /**
+    *@group cmd
+    */
     public function testLaravelCommandworks()
     {
         $process = new Process('~/.composer/vendor/bin/laravel --version');

--- a/tests/A74ComposerTest.php
+++ b/tests/A74ComposerTest.php
@@ -5,6 +5,9 @@ use Symfony\Component\Process\Process;
 class A74LaravelInstallerTest extends TestCase
 {
 
+    /**
+    *@group cmd
+    */
     public function testComposerCommandworks()
     {
         $process = new Process('composer --version');

--- a/tests/A81OPCacheTest.php
+++ b/tests/A81OPCacheTest.php
@@ -1,0 +1,20 @@
+<?php
+
+class A81OPCacheTest extends TestCase
+{
+    /**
+    *@group dev
+    */
+    public function testOPcacheDisableDuringDevlopment()
+    {
+        $this->assertFalse($this->isExtensionLoaded('Zend OPcache'));
+    }
+
+    /**
+    *@group prod
+    */
+    public function testOPCacheEnableDuringProduction()
+    {
+        $this->assertTrue($this->isExtensionLoaded('Zend OPcache'));
+    }
+}

--- a/tests/A82XdebugTest.php
+++ b/tests/A82XdebugTest.php
@@ -1,0 +1,32 @@
+<?php
+
+class A82XdebugTest extends TestCase
+{
+    /**
+    *@group dev
+    */
+    public function testXdebugEnableDuringDevlopment()
+    {
+        $this->assertSame(
+            true,
+            $this->isExtensionLoaded('xdebug'),
+            "Xdebug is not installed. You will not be able to generate PHPUnit code coverage report."
+        );
+
+        $this->assertSame('1', ini_get('xdebug.remote_enable'));
+        $this->assertSame('1', ini_get('xdebug.remote_connect_back'));
+        $this->assertSame('9000', ini_get('xdebug.remote_port'));
+        $this->assertSame('dbgp', ini_get('xdebug.remote_handler'));
+        $this->assertSame('req', ini_get('xdebug.remote_mode'));
+        $this->assertSame('1', ini_get('xdebug.cli_color'));
+        $this->assertSame('2', ini_get('xdebug.overload_var_dump'));
+    }
+
+    /**
+    *@group prod
+    */
+    public function testXdebugDisableDuringProduction()
+    {
+        $this->assertFalse($this->isExtensionLoaded('xdebug'));
+    }
+}


### PR DESCRIPTION
Solve rasodu/DLEMPFast#3 in production. Thought during development mode page load will still be slow. It is not recommended to run OPCache with Xdebug(or APC). Therefore, we didn't enable it development containers(phpfpmdev and cmd).
