### PR TITLE
Changes to support Laravel 5.3

### DIFF
--- a/docker/dockerfile/56phpfpmdevlaravel
+++ b/docker/dockerfile/56phpfpmdevlaravel
@@ -8,6 +8,8 @@ ARG DLEMP_PHP_VERSION
 RUN apt-get update && apt-get -y install wget \
     && docker-php-ext-install mbstring \
     && docker-php-ext-install pdo_mysql \
+    && apt-get -y install libxml2-dev && docker-php-ext-install xml \
+    && docker-php-ext-install pcntl \
     && apt-get -y install libmcrypt-dev && docker-php-ext-install mcrypt \
     && apt-get -y install zlib1g zlib1g-dev && docker-php-ext-install zip \
     && apt-get -y install libmemcached-dev zlib1g-dev && pecl install memcached && docker-php-ext-enable memcached \

--- a/docker/dockerfile/56phpfpmlaravel
+++ b/docker/dockerfile/56phpfpmlaravel
@@ -8,6 +8,8 @@ ARG DLEMP_PHP_VERSION
 RUN apt-get update && apt-get -y install wget \
     && docker-php-ext-install mbstring \
     && docker-php-ext-install pdo_mysql \
+    && apt-get -y install libxml2-dev && docker-php-ext-install xml \
+    && docker-php-ext-install pcntl \
     && apt-get -y install libmcrypt-dev && docker-php-ext-install mcrypt \
     && apt-get -y install zlib1g zlib1g-dev && docker-php-ext-install zip \
     && apt-get -y install libmemcached-dev zlib1g-dev && pecl install memcached && docker-php-ext-enable memcached \

--- a/docker/dockerfile/70phpfpmdevlaravel
+++ b/docker/dockerfile/70phpfpmdevlaravel
@@ -8,6 +8,8 @@ ARG DLEMP_PHP_VERSION
 RUN apt-get update && apt-get -y install wget \
     && docker-php-ext-install mbstring \
     && docker-php-ext-install pdo_mysql \
+    && apt-get -y install libxml2-dev && docker-php-ext-install xml \
+    && docker-php-ext-install pcntl \
     && apt-get -y install libmcrypt-dev && docker-php-ext-install mcrypt \
     && apt-get -y install zlib1g zlib1g-dev && docker-php-ext-install zip \
     && apt-get -y install libmemcached-dev zlib1g-dev \

--- a/docker/dockerfile/70phpfpmlaravel
+++ b/docker/dockerfile/70phpfpmlaravel
@@ -8,6 +8,8 @@ ARG DLEMP_PHP_VERSION
 RUN apt-get update && apt-get -y install wget \
     && docker-php-ext-install mbstring \
     && docker-php-ext-install pdo_mysql \
+    && apt-get -y install libxml2-dev && docker-php-ext-install xml \
+    && docker-php-ext-install pcntl \
     && apt-get -y install libmcrypt-dev && docker-php-ext-install mcrypt \
     && apt-get -y install zlib1g zlib1g-dev && docker-php-ext-install zip \
     && apt-get -y install libmemcached-dev zlib1g-dev \

--- a/tests/A01PHPLaravelTest.php
+++ b/tests/A01PHPLaravelTest.php
@@ -8,7 +8,7 @@ class A01PHPLaravelTest extends TestCase
 
     public function testPhpVersionRequiredByLaravel()
     {
-        $laravel_minimum_php_version= '5.5.9';
+        $laravel_minimum_php_version= '5.6.4';
         $installed_version= phpversion();
 
         $this->assertSame(
@@ -128,6 +128,25 @@ class A01PHPLaravelTest extends TestCase
             true,
             $this->isExtensionLoaded('tokenizer'),
             "Tokenizer is not installed. Tokenizer is required by Laravel."
+        );
+    }
+
+
+    public function testXml()
+    {
+        $this->assertSame(
+            true,
+            $this->isExtensionLoaded('xml'),
+            "XML is not installed. XML is required by Laravel."
+        );
+    }
+
+    public function testPcntl()
+    {
+        $this->assertSame(
+            true,
+            $this->isExtensionLoaded('pcntl'),
+            "Pcntl is not installed. Pcntl is required if you want to set timeout in queue worker."
         );
     }
 


### PR DESCRIPTION
Following changes are made
- Require minimum php verson of 5.6.4
- Install additional extension XML
- Install additional extension pcntl(required if you want to set timeout on your queue worker)
