### PR TITLE
Remove Gulp from cmd image

### DIFF
--- a/docker/dockerfile/cmd
+++ b/docker/dockerfile/cmd
@@ -5,7 +5,6 @@ FROM dlemp/phpfpm
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt-get install -y nodejs \
     && apt-get install -y libnotify-bin
-RUN npm install --global gulp@^3.8.8
     #end install node
 
     #start install phar installer


### PR DESCRIPTION
We are supporting multiple versions of Laravel. Different version of Laravel require different version of gulp. Therefore we are removing gulp from our cmd image. From now on user is responsible for installing gulp.
