### PR TITLE
Add volumes for redis and beanstalkd

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -13,6 +13,10 @@ services:
     elasticsearch:
         volumes:
             - elasticsearch-data:/usr/share/elasticsearch/data
+    beanstalkd:
+        command: beanstalkd -p 11300 -u nobody -b /var/lib/beanstalkd
+        volumes:
+            - data-beanstalkd:/var/lib/beanstalkd
 #end These services can be disabled without affecting any other services
     nginxhttp:
         volumes:
@@ -35,4 +39,6 @@ volumes:
     elasticsearch-data:
         driver: local
     acme-challenge:
+        driver: local
+    data-beanstalkd:
         driver: local

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -17,6 +17,10 @@ services:
         command: beanstalkd -p 11300 -u nobody -b /var/lib/beanstalkd
         volumes:
             - data-beanstalkd:/var/lib/beanstalkd
+    redis:
+        command: redis-server --appendonly yes
+        volumes:
+            - data-redis:/data
 #end These services can be disabled without affecting any other services
     nginxhttp:
         volumes:
@@ -41,4 +45,6 @@ volumes:
     acme-challenge:
         driver: local
     data-beanstalkd:
+        driver: local
+    data-redis:
         driver: local

--- a/compose.yml
+++ b/compose.yml
@@ -31,7 +31,7 @@ services:
 #end These services can be disabled without affecting any other services
 #start Disabling these services require that you also disable services that depends on the services that you are disabling.
     beanstalkd: #Also turn off: workerlaravel
-        image: kusmierz/beanstalkd:v1.10.0
+        image: rasodu/beanstalkd:v1.10.1
         expose:
             - "11300"
     redis: #Also turn off: pusherlaravel


### PR DESCRIPTION
Create volume for beanstalkd and redis. If the computer is abruptly stopped for some reason, then redis and beanstalkd will not loss data.
### beanstalkd

http://stackoverflow.com/questions/30489788/preserve-beanstalkd-queue-on-restart-or-crash
https://github.com/kr/beanstalkd/wiki/faq#are-the-jobs-persistent-what-happens-if-the-power-goes-out
### redis

https://hub.docker.com/_/redis/
http://redis.io/topics/persistence
