### PR TITLE
Default time zone in php.ini is set to UTC.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 ### Added
+- Default time on php.ini is set to UTC (2016-10-29)
 - Elasticsearch(version 5.0.0) container is added.
 ### Fixed

--- a/docker/docker-config/php.ini-common-delta
+++ b/docker/docker-config/php.ini-common-delta
@@ -1,5 +1,8 @@
 ; This file file is used to overwrite configurations in '/usr/local/etc/php/php.ini' file
 
+; Set default time zone to UTC
+date.timezone = "UTC"
+
 ; Turn off x-powered-by:"PHP/5.6.21" header
 expose_php = off
 

--- a/tests/Services/Phpfpm/DlempTest.php
+++ b/tests/Services/Phpfpm/DlempTest.php
@@ -8,6 +8,11 @@ class DlempTest extends TestCase
         $this->assertSame('GP', ini_get('request_order'));
     }
 
+    public function testDefaultTimeZone()
+    {
+        $this->assertSame('UTC', date_default_timezone_get(), 'Default display timezone is not UTC');
+    }
+
     /**
     *@group dev
     */


### PR DESCRIPTION
Changes discussed in #59 are applied here. 
