### PR TITLE
Build docker images with docker build command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - nginxhttps service is split into nginxhttps and httpbackend (2016-12-05)
 
 ### Added
+- docker-compose no longer responsible for building images(2017-05-06)
 - PHP 7.1 support is added (2017-01-28)
 - Laravel Echo server support is added (2017-01-26)
 - Nodejs server support is added (2017-01-22)

--- a/Command to build
+++ b/Command to build
@@ -4,11 +4,11 @@ docker login
     //end login to docker hub
 
     //start push phpfpmdev service
-docker tag dlemp/phpfpm rasodu/phpfpmdevlaravel:5.6.<version_number>
+docker tag rasodu/phpfpmdevlaravel:dev rasodu/phpfpmdevlaravel:5.6.<version_number>
 docker push rasodu/phpfpmdevlaravel:5.6.<version_number>
     //end push phpfpmdev service
     //start push cmd service
-docker tag dlemp_cmd rasodu/cmdlaravel:5.6.<version_number>
+docker tag rasodu/cmdlaravel:dev rasodu/cmdlaravel:5.6.<version_number>
 docker push rasodu/cmdlaravel:5.6.<version_number>
     //end push cmd service
     //start push certbot service
@@ -35,13 +35,12 @@ docker push rasodu/broadcasterlaravelechoserver:<version_number>
 
     //start push phpfpm
 #put app in production mode by changing 'COMPOSE_FILE' in '.env' file
-docker-compose build phpfpm
-docker history dlemp/phpfpm
+docker history rasodu/phpfpmlaravel:dev
 docker tag <image-id-of-layer> rasodu/phpfpmlaravel:5.6.<version_number>//Tag at layer before installing xdebug
 docker push rasodu/phpfpmlaravel:5.6.<version_number>
     //end push phpfpm
     //start push httpbackend
-docker history dlemp_httpbackend
+docker history rasodu/httpbackendlaravelnginx:dev
 docker tag <image-id-of-layer> rasodu/httpbackendlaravelnginx:1.10.<version_number>//Tag at layer before copying 'public' directory to the image
 docker push rasodu/httpbackendlaravelnginx:1.10.<version_number>
     //end push httpbackend

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,13 @@ node_modules: package.json
 
 	#build and start containers
 PHONY += all
-all: node_modules
-	$(COMPOSE) build
+all: docker_build_images node_modules
 	$(COMPOSE) up -d
+
+PHONY += docker_build_images
+docker_build_images:
+	$(COMPOSE) build
+
 
 	#run unittests
 PHONY += test

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,21 @@ all: docker_build_images node_modules
 
 PHONY += docker_build_images
 docker_build_images:
-	$(COMPOSE) build
+	#images pushed to docker hub
+	docker build --build-arg DLEMP_BASE_DIR=$(DLEMP_BASE_DIR) --build-arg DLEMP_PHP_VERSION=${DLEMP_PHP_VERSION} --tag rasodu/phpfpmdevlaravel:dev -f $(DLEMP_BASE_DIR)docker/dockerfile/$(DLEMP_PHP_VERSION)phpfpmdevlaravel .
+	docker build --tag rasodu/cmdlaravel:dev -f $(DLEMP_BASE_DIR)docker/dockerfile/cmd .
+	docker run --rm --user=$$(id -u):$$(id -g) -v $$(pwd):/usr/share/nginx/WEBAPP rasodu/cmdlaravel:dev composer install
+	docker build --build-arg DLEMP_BASE_DIR=$(DLEMP_BASE_DIR) --build-arg DLEMP_PHP_VERSION=${DLEMP_PHP_VERSION} --tag rasodu/phpfpmlaravel:dev -f $(DLEMP_BASE_DIR)docker/dockerfile/$(DLEMP_PHP_VERSION)phpfpmlaravel .
+	docker build --build-arg DLEMP_BASE_DIR=$(DLEMP_BASE_DIR) --tag rasodu/httpbackendlaravelnginx:dev -f $(DLEMP_BASE_DIR)docker/dockerfile/httpbackendlaravelnginx .
+	docker build --build-arg DLEMP_BASE_DIR=$(DLEMP_BASE_DIR) --tag rasodu/httpsnginx:dev -f $(DLEMP_BASE_DIR)docker/dockerfile/httpsnginx .
+	docker build --build-arg DLEMP_BASE_DIR=$(DLEMP_BASE_DIR) --tag rasodu/httpnginx:dev -f $(DLEMP_BASE_DIR)docker/dockerfile/httpnginx .
+	docker build --build-arg DLEMP_BASE_DIR=$(DLEMP_BASE_DIR) --tag rasodu/cron:dev -f $(DLEMP_BASE_DIR)docker/dockerfile/cron .
+	docker build --build-arg DLEMP_BASE_DIR=$(DLEMP_BASE_DIR) --tag rasodu/broadcasterlaravelechoserver:dev -f $(DLEMP_BASE_DIR)docker/dockerfile/broadcasterlaravelechoserver .
+	docker build --build-arg DLEMP_BASE_DIR=$(DLEMP_BASE_DIR) --tag rasodu/pusherlaravel:dev -f $(DLEMP_BASE_DIR)docker/dockerfile/pusherlaravel .
+	docker build --build-arg DLEMP_BASE_DIR=$(DLEMP_BASE_DIR) --tag rasodu/s3mock:dev -f $(DLEMP_BASE_DIR)docker/dockerfile/s3mock .
+	docker build --build-arg DLEMP_BASE_DIR=$(DLEMP_BASE_DIR) --tag rasodu/certbot:dev -f $(DLEMP_BASE_DIR)docker/dockerfile/httpnginx .
+	#images not pushed to docker hub
+	docker build --build-arg DLEMP_BASE_DIR=$(DLEMP_BASE_DIR) --tag rasodu/6nodejs:dev -f $(DLEMP_BASE_DIR)docker/dockerfile/6nodejs .
 
 
 	#run unittests

--- a/compose.laravel.override.yml
+++ b/compose.laravel.override.yml
@@ -1,8 +1,7 @@
 version: '2'
 services:
     phpfpm:
-        build:
-            dockerfile: ${DLEMP_BASE_DIR}docker/dockerfile/${DLEMP_PHP_VERSION}phpfpmdevlaravel
+        image: rasodu/phpfpmdevlaravel:dev
     pusher:
         ports:
             - "7000:7001"

--- a/compose.laravel.yml
+++ b/compose.laravel.yml
@@ -2,27 +2,19 @@ version: '2'
 services:
 #start These services can be disabled without affecting any other services
     pusher:
-        build:
-            context: .
-            dockerfile: ${DLEMP_BASE_DIR}docker/dockerfile/pusherlaravel
-            args:
-                DLEMP_BASE_DIR: ${DLEMP_BASE_DIR}
+        image: rasodu/pusherlaravel:dev
         depends_on:
             - redis
         expose:
             - "7001"
     broadcaster:
-        build:
-            context: .
-            dockerfile: ${DLEMP_BASE_DIR}docker/dockerfile/broadcasterlaravelechoserver
-            args:
-                DLEMP_BASE_DIR: ${DLEMP_BASE_DIR}
+        image: rasodu/broadcasterlaravelechoserver:dev
         depends_on:
             - redis
         expose:
             - "6001"
     worker:
-        image: dlemp/phpfpm
+        image: rasodu/phpfpmlaravel:dev
         depends_on:
             - beanstalkd
             - phpfpm
@@ -31,14 +23,8 @@ services:
             - phpfpm
 #end These services can be disabled without affecting any other services
     phpfpm:
-        build:
-            dockerfile: ${DLEMP_BASE_DIR}docker/dockerfile/${DLEMP_PHP_VERSION}phpfpmlaravel
+        image: rasodu/phpfpmlaravel:dev
     https:
-        build:
-            dockerfile: ${DLEMP_BASE_DIR}docker/dockerfile/httpsnginx
+        image: rasodu/httpsnginx:dev
     httpbackend:
-        build:
-            context: .
-            dockerfile: ${DLEMP_BASE_DIR}docker/dockerfile/httpbackendlaravelnginx
-            args:
-                DLEMP_BASE_DIR: ${DLEMP_BASE_DIR}
+        image: rasodu/httpbackendlaravelnginx:dev

--- a/compose.override.yml
+++ b/compose.override.yml
@@ -2,11 +2,7 @@ version: '2'
 services:
 #start These services can be disabled without affecting any other services
     webapp.dev: #s3mock service is given this name for easy internal excess
-        build:
-            context: .
-            dockerfile: ${DLEMP_BASE_DIR}docker/dockerfile/s3mock
-            args:
-                DLEMP_BASE_DIR: ${DLEMP_BASE_DIR}
+        image: rasodu/s3mock:dev
         ports:
             - "4569:4569"
     smtp:
@@ -27,9 +23,7 @@ services:
         ports:
             - "80:80"
     cmd:
-        build:
-            context: .
-            dockerfile: ${DLEMP_BASE_DIR}docker/dockerfile/cmd
+        image: rasodu/cmdlaravel:dev
         ports:
             - "3002:3000"
             - "3001:3001"

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -2,11 +2,7 @@ version: '2'
 services:
 #start These services can be disabled without affecting any other services
     cron:
-        build:
-            context: .
-            dockerfile: ${DLEMP_BASE_DIR}docker/dockerfile/cron
-            args:
-                DLEMP_BASE_DIR: ${DLEMP_BASE_DIR}
+        image: rasodu/cron:dev
     mysql:
         volumes:
             - var-lib-mysql:/var/lib/mysql
@@ -21,21 +17,13 @@ services:
             - data-redis:/data
 #end These services can be disabled without affecting any other services
     http:
-        build:
-            context: .
-            dockerfile: ${DLEMP_BASE_DIR}docker/dockerfile/httpnginx
-            args:
-                DLEMP_BASE_DIR: ${DLEMP_BASE_DIR}
+        image: rasodu/httpnginx:dev
         ports:
             - "80:80"
         volumes:
             - acme-challenge:/DLEMP/certbot/public/.well-known/acme-challenge
     certbot:
-        build:
-            context: .
-            dockerfile: ${DLEMP_BASE_DIR}docker/dockerfile/certbot
-            args:
-                DLEMP_BASE_DIR: ${DLEMP_BASE_DIR}
+        image: rasodu/certbot:dev
         depends_on:
             - https
         volumes_from:

--- a/compose.yml
+++ b/compose.yml
@@ -37,12 +37,6 @@ services:
             - "6379"
 #end Disabling these services require that you also disable services that depends on the services that you are disabling.
     phpfpm:
-        build:
-            context: .
-            args:
-                DLEMP_BASE_DIR: ${DLEMP_BASE_DIR}
-                DLEMP_PHP_VERSION: ${DLEMP_PHP_VERSION}
-        image: dlemp/phpfpm
         expose:
             - "9000"
     httpbackend:
@@ -53,18 +47,10 @@ services:
         expose:
             - "80"
     nodejs:
-        build:
-            context: .
-            dockerfile: ${DLEMP_BASE_DIR}docker/dockerfile/6nodejs
-            args:
-                DLEMP_BASE_DIR: ${DLEMP_BASE_DIR}
+        image: rasodu/6nodejs:dev
         expose:
             - "8080"
     https:
-        build:
-            context: .
-            args:
-                DLEMP_BASE_DIR: ${DLEMP_BASE_DIR}
         depends_on:
             - httpbackend
         ports:

--- a/docker/dockerfile/cmd
+++ b/docker/dockerfile/cmd
@@ -1,4 +1,4 @@
-FROM dlemp/phpfpm
+FROM rasodu/phpfpmdevlaravel:dev
 
 #start everything specific 'dlemp_cmd' file
     #start install node


### PR DESCRIPTION
According to #85, ```docker-compose``` should only be used to run images. It should not be used to build images. This pull request adds separate make target to build image. The target builds the image directly using ```docker build``` command.